### PR TITLE
removed for loop, added samples argument

### DIFF
--- a/crg.call-svs.sh
+++ b/crg.call-svs.sh
@@ -28,7 +28,7 @@ else
 		if [ -f ${bam_file} ];
 		then
 			ln -s ${bam_file} ${sample}.bam
-			decoy_jobs+=($(qsub ~/cre/cre.bam.remove_decoy_reads.sh -v bam=${sample}.bam))
+			decoy_jobs+=($(qsub ~/cre/cre.bam.remove_decoy_reads.sh -v bam=${sample}.bam)) 
 		else
 			echo "Aligned bam file not found for sample ${bam_file}"
 			exit
@@ -54,11 +54,13 @@ do
 	mkdir -p ${sample}/${family_id}/input
 	if [ -z ${decoy_string} ];
 	then
-		setup_bcbio=$(qsub ~/crg/crg.setup.individual-sv.sh -v family_id="${family_id}")
+		#pass $family_id and $sample to crg.setup.individual-sv.sh
+		setup_bcbio=$(qsub ~/crg/crg.setup.individual-sv.sh -v family_id="${family_id}",sample="${sample}") 
 	else
-		setup_bcbio=$(qsub ~/crg/crg.setup.individual-sv.sh -v family_id="${family_id}" -W depend=afterany:"${decoy_string}")
+		setup_bcbio=$(qsub ~/crg/crg.setup.individual-sv.sh -v family_id="${family_id}",sample="${sample}" -W depend=afterany:"${decoy_string}")
 	fi
 	# submit bcbio job to run after setup complete
+
 	cd ${sample}
 	bcbio_jobs+=($(qsub ~/cre/bcbio.pbs -v project="${family_id}" -W depend=afterany:"${setup_bcbio}"))
 	cd ..

--- a/crg.setup.individual-sv.sh
+++ b/crg.setup.individual-sv.sh
@@ -4,29 +4,26 @@
 #PBS -d .
 #PBS -l vmem=21g,mem=21g
 
-for f in ${family_id}*; 
-do
-	echo $f
-	if [ -d $f ]
-	then 
-		cd $f/${family_id}/input;
-		ln -s ../../../../remove_decoys/${f}.no_decoy_reads.bam $f.bam; 
-		cd ../../..;
-	else
-		echo "Decoy file not found"
-	fi
+#arguments passed: family_id and sample 
 
-done
+echo "sample = $sample";
+if [ -d $sample ]
+then
+	cd $sample/${family_id}/input;
+	ln -s ../../../../remove_decoys/${sample}.no_decoy_reads.bam $sample.bam; 
+	cd ../../..;
+else
+	echo "Decoy file not found"
+fi
 
-for f in ${family_id}*; 
-do 
-	if [ -d $f ]
-	then
-		cd $f;
-		pwd
-		~/crg/crg.prepare_bcbio_run.sh ${family_id} sv;
-		cd ..;
-	else
-		echo "Participant Folder Not Found."
-	fi
-done
+
+if [ -d $sample ]
+then
+	cd $sample;
+	echo "current directory: `pwd`";
+	~/crg/crg.prepare_bcbio_run.sh ${family_id} sv;
+	cd ..;
+else
+	echo "Participant Folder Not Found."
+fi
+


### PR DESCRIPTION
crg.setup.individual-sv.sh: removed two `for` loops, since it repeatedly tries to create symlink and runs `crg.prepare_bcbio_run.sh` for all sample every time instead of each sample.

crg.call-svs.sh: added a second argument `$samples` to the call to `crg.setup.individual-sv.sh`