### PR TITLE
script to submit jobs for  merging, annotating, and scoring svs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,23 +51,11 @@ note crg.vcf2cre.sh not cre.vcf2cre.sh: annotations for WGS are different
 6. Perform steps 3-5 for the `<project>.flank.100k.bed` file and within the `panel-flank100k` folder
 
 # 5. Call Structural Variants (In Parallel with Step 3.)
-1. Run the `~/crg/crg.call-svs.sh <project>` script to set up the pipeline for SV calling. It will submit jobs to remove decoys and run SV calling for samples individually. The script will print the commands to perfom the following steps *after* the bcbio jobs are completed, they are explained below.
-2. Run `metasv.pbs -v PROJECT=<project>,SAMPLE=<sample>` within each sample's `final` dir:
-```
-for f in <project>_*/<project>/final/<project>*; do cd $f; pwd; ls; qsub ~/crg/metasv.pbs -v PROJECT=<project>,SAMPLE="$(echo $f | sed -n -e 's/.*_//p')"; cd ../../../..; done")'
-```
-3. After MetaSV, is done, annotate the VCF files with snpEff (`qsub ~/crg/crg.snpeff.sh -F <project>-metasv.vcf.gz`) and then svScore (`qsub ~/crg/crg.svscore.sh -F <project>-snpeff.vcf.gz`): 
-```
-for f in <project>_*/<project>/final/<project>_*/*/*metasv*.gz; do qsub ~/crg/crg.snpeff.sh -F $f; ls; done
-```
-and 
-```
-for f in <project>_*/<project>/final/<project>*; do cd $f; pwd; ls; qsub ~/crg/metasv.pbs -v PROJECT=<project>,SAMPLE="$(echo $f | sed -n -e 's/.*_//p')"; cd ../../../..; done")
-```
+1. Run the `~/crg/crg.call-svs.sh <project>` script to set up the pipeline for SV calling. It will submit jobs to remove decoys and run SV calling for samples individually.
 
-# 8. Excel report for structural variants 
+# 6. Excel report for structural variants 
 1. [Report columns](https://docs.google.com/document/d/1o870tr0rcshoae_VkG1ZOoWNSAmorCZlhHDpZuZogYE/edit?usp=sharing)
-2. Create a directory, link the final annotated VCF files into it, and run the intersect sv script: `~/crg/crg.intersect_sv_vcfs.sh -F <project>`. To include HPO terms in the report, put the file from PhenomeCentral in the `~/gene_data/HPO` folder named by `<project>_HPO.txt`.
+2. cd into the bcbio-sv directory and run the merging and annotation script: `~/crg/crg.merge.annotate.sv.sh <project>`. To include HPO terms in the report, put the file from PhenomeCentral in the `~/gene_data/HPO` folder named by `<project>_HPO.txt`.
 3. (Optional) Generate per sample reports: \
 3.1 `cd <sample_dir>`\
 3.2 `qsub ~/crg/crg.sv.prioritize.sh -v case=<project>,panel=<panel.bed>`\

--- a/crg.call-svs.sh
+++ b/crg.call-svs.sh
@@ -68,16 +68,3 @@ done
 bcbio_string=$( IFS=$':'; echo "${bcbio_jobs[*]}" )
 
 echo "Setup Complete."
-echo "Save the following commands, and once bcbio jobs: "$( IFS=$', '; echo "${bcbio_jobs[*]}" ) " are done, run them from within the bcbio-sv folder"
-echo "MetaSV:"
-echo '	for f in '${family_id}'_*/'${family_id}'/final/'${family_id}'*; do cd $f; pwd; ls; qsub ~/crg/metasv.pbs -v PROJECT=${family_id},SAMPLE="$(echo $f | sed -n -e 's/.*_//p')"; cd ../../../..; done")'
-echo "SnpEff:"
-echo '	for f in '${family_id}'_*/'${family_id}'/final/'${family_id}'_*/*/*metasv*.gz; do qsub ~/crg/crg.snpeff.sh -F $f; ls; done'
-echo "SVScore:"
-echo '	for f in '${family_id}'_*/'${family_id}'/final/'${family_id}'_*/*/*snpeff*.vcf; do qsub ~/crg/crg.svscore.sh -F $f; done'
-echo "Then create a directory to combine SVScore VCFs and link them:"
-echo '	mkdir combine_vcfs'
-echo '	cd combine_vcfs'
-echo '	for f in ../'${family_id}'_*/'${family_id}'/final/'${family_id}'_*/*/*svscore*.vcf;do ln -s $f . ; done'
-echo "Finally, run the intersect sv script:"
-echo '	~/crg/crg.intersect_sv_vcfs.sh -F '${family_id}

--- a/crg.intersect_sv_vcfs.sh
+++ b/crg.intersect_sv_vcfs.sh
@@ -27,7 +27,8 @@ MSSNG_MANTA_COUNTS=${GENE_DATA}/mssng_counts/Canadian_MSSNG_parent_SVs.Manta.cou
 MSSNG_LUMPY_COUNTS=${GENE_DATA}/mssng_counts/Canadian_MSSNG_parent_SVs.LUMPY.counts.txt
 
 if [ ! $2 ]; then
-	IN_FILES=`ls $FAMILY_*/$FAMILY/final/$FAMILY*/$FAMILY*/*svscore.vcf | tr '\n' ' '`
+	FAMILY=$1
+	IN_FILES=`ls ${FAMILY}_*/${FAMILY}/final/${FAMILY}*/${FAMILY}*/*svscore.vcf | tr '\n' ' '`
 else
 	IN_FILES=${*:2}
 fi

--- a/crg.intersect_sv_vcfs.sh
+++ b/crg.intersect_sv_vcfs.sh
@@ -27,7 +27,7 @@ MSSNG_MANTA_COUNTS=${GENE_DATA}/mssng_counts/Canadian_MSSNG_parent_SVs.Manta.cou
 MSSNG_LUMPY_COUNTS=${GENE_DATA}/mssng_counts/Canadian_MSSNG_parent_SVs.LUMPY.counts.txt
 
 if [ ! $2 ]; then
-	IN_FILES=`ls *.vcf | tr '\n' ' '`
+	IN_FILES=`ls $FAMILY_*/$FAMILY/final/$FAMILY*/$FAMILY*/*svscore.vcf | tr '\n' ' '`
 else
 	IN_FILES=${*:2}
 fi

--- a/crg.merge.annotate.sv.sh
+++ b/crg.merge.annotate.sv.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# usage: crg.merge.annotate.sv.sh <family>
+# run from within family/bcbio-sv/ 
+
+FAMILY=$1
+
+#run metasv on each sample
+for f in $FAMILY_*/$FAMILY/final/$FAMILY* 
+do 
+	cd $f
+	SAMPLE="$(echo $f | cut -d'/' -f1)"
+	metasv_jobs+=($(qsub ~/crg/metasv.pbs -v SAMPLE=$SAMPLE,FAMILY=$FAMILY))
+	cd ../../../..
+done
+metasv_string=$( IFS=$':'; echo "${metasv_jobs[*]}" )
+
+#run snpeff on each sample
+for f in $FAMILY_*/$FAMILY/final/$FAMILY*
+do
+	SAMPLE="$(echo $f | cut -d'/' -f1)"
+	snpeff_jobs+=($(qsub ~/crg/crg.snpeff.sh -F $f/$SAMPLE/*metasv.filtered.vcf.gz -W depend=afterany:"${metasv_string}"))
+done
+snpeff_string=$( IFS=$':'; echo "${snpeff_jobs[*]}" )
+
+#run svscore on each sample
+for f in $FAMILY_*/$FAMILY/final/$FAMILY*
+do
+	SAMPLE="$(echo $f | cut -d'/' -f1)"
+	snpeff_jobs+=($(qsub ~/crg/crg.svscore.sh -F $f/$SAMPLE/*snpeff.vcf -W depend=afterany:"${snpeff_string}"))
+done
+
+echo "Merging SVs with metaSV, annotating with snpeff, and scoring with svscore..."
+
+

--- a/crg.merge.annotate.sv.sh
+++ b/crg.merge.annotate.sv.sh
@@ -26,9 +26,12 @@ snpeff_string=$( IFS=$':'; echo "${snpeff_jobs[*]}" )
 for f in $FAMILY_*/$FAMILY/final/$FAMILY*
 do
 	SAMPLE="$(echo $f | cut -d'/' -f1)"
-	snpeff_jobs+=($(qsub ~/crg/crg.svscore.sh -F $f/$SAMPLE/*snpeff.vcf -W depend=afterany:"${snpeff_string}"))
+	svscore_jobs+=($(qsub ~/crg/crg.svscore.sh -F $f/$SAMPLE/*snpeff.vcf -W depend=afterany:"${snpeff_string}"))
 done
+svscore_string=$( IFS=$':'; echo "${svscore_jobs[*]}" )
 
 echo "Merging SVs with metaSV, annotating with snpeff, and scoring with svscore..."
 
+#ln -s $FAMILY_*/$FAMILY/final/$FAMILY*/$FAMILY*/*svscore.vcf .
+qsub ~/crg/crg.intersect_sv_vcfs.sh -F $FAMILY  -W depend=afterany:"${svscore_string}"
 

--- a/crg.merge.annotate.sv.sh
+++ b/crg.merge.annotate.sv.sh
@@ -30,8 +30,7 @@ do
 done
 svscore_string=$( IFS=$':'; echo "${svscore_jobs[*]}" )
 
-echo "Merging SVs with metaSV, annotating with snpeff, and scoring with svscore..."
+echo "Merging SVs with metaSV, annotating with snpeff, scoring with svscore, and creating report..."
 
-#ln -s $FAMILY_*/$FAMILY/final/$FAMILY*/$FAMILY*/*svscore.vcf .
 qsub ~/crg/crg.intersect_sv_vcfs.sh -F $FAMILY  -W depend=afterany:"${svscore_string}"
 

--- a/metasv.pbs
+++ b/metasv.pbs
@@ -3,8 +3,7 @@
 #PBS -l walltime=0:20:00,nodes=1:ppn=4
 #PBS -joe .
 #PBS -d .
-#PBS -l vmem=4g,mem=4g
+#PBS -l vmem=8g,mem=8g
 
-SAMPLE=$1
 
-python ~/crg/metasv.py -bam ${SAMPLE}.bam -manta $SAMPLE"-manta.vcf.gz" -lumpy $SAMPLE"-lumpy.vcf.gz" -wham $SAMPLE"-wham.vcf.gz" -sample $SAMPLE
+python ~/crg/metasv.py -bam ${SAMPLE}-ready.bam -manta $FAMILY"-manta.vcf.gz" -lumpy $FAMILY"-lumpy.vcf.gz" -wham $FAMILY"-wham.vcf.gz" -sample $SAMPLE


### PR DESCRIPTION
Adds a script (crg.merge.annotate.sv.sh) to automate metasv, snpeff, and svscore steps for all samples in a family. Makes relevant changes to metaSV to correct sample naming. 