### PR TITLE
Compare SVs and CNVs

### DIFF
--- a/compare_sv_cnv.py
+++ b/compare_sv_cnv.py
@@ -1,0 +1,84 @@
+import argparse
+import numpy as np
+import pandas as pd
+from pybedtools import BedTool
+
+
+def intersect_variants(cnv, sv):
+    # get coordinates of DEL and DUP from SV and CNV reports
+    sv_coord = sv[['CHROM', 'POS', 'END', 'SVTYPE']]
+    sv_coord = sv_coord[(sv_coord['SVTYPE'] != 'INV')
+                        & (sv_coord['SVTYPE'] != 'INS')]
+    cnv_coord = cnv[['CHROM', 'START', 'END', 'SVTYPE']]
+
+    # convert report dataframes to bedtools
+    cnv_bed = BedTool.from_dataframe(cnv_coord)
+    sv_bed = BedTool.from_dataframe(sv_coord)
+
+    # prepare empty dataframe for overlaps
+    intersection = pd.DataFrame(columns=['CNV_CHROM', 'CNV_START', 'CNV_END', 'CNV_SVTYPE', 'SV_CHROM',
+                                         'SV_START', 'SV_END', 'SV_SVTYPE']).set_index(['CNV_CHROM', 'CNV_START', 'CNV_END', 'CNV_SVTYPE'])
+
+    # intersect CNV and SV bed files with reciprocal overlap of 50%
+    for i in cnv_bed.intersect(sv_bed, wa=True, wb=True, F=0.5, f=0.5):
+        cnv_chrom, cnv_start, cnv_end, cnv_type, \
+            sv_chrom, sv_start, sv_end, sv_type = i
+        cnv_interval = (cnv_chrom, cnv_start, cnv_end, cnv_type)
+        sv_interval = (sv_chrom, sv_start, sv_end, sv_type)
+
+        # only compare like SV types
+        if cnv_type != sv_type:
+            pass
+        else:
+            intersection.loc[cnv_interval] = sv_interval
+
+    intersection = intersection.sort_index().reset_index()
+    # change start and end coordinates to integer data type
+    for col in ['CNV_START', 'CNV_END',  'SV_START', 'SV_END']:
+        intersection[col] = intersection[col].astype(int)
+
+    # make reports updated with overlap column
+    merged_cnv = update_report(cnv, intersection, 'CNV')
+    merged_sv = update_report(sv, intersection, 'SV')
+    return merged_cnv, merged_sv
+
+
+def update_report(report_df, intersection, variant_type):
+    # join overlap dataframe with report dataframe to annotate overlaps
+    if variant_type == 'CNV':
+        merged = report_df.merge(intersection, how='left', left_on=['CHROM', 'START', 'END', 'SVTYPE'], right_on=[
+                                 'CNV_CHROM', 'CNV_START', 'CNV_END', 'CNV_SVTYPE'])
+        overlap = []
+        overlap = ['{}:{}-{}'.format(row['SV_CHROM'], int(row['SV_START']), int(row['SV_END']))
+                   if row['SV_START'] == row['SV_START'] else 'nan' for index, row in merged.iterrows()]
+        merged['SV_overlap'] = overlap
+    else:
+        merged = report_df.merge(intersection, how='left', left_on=['CHROM', 'POS', 'END', 'SVTYPE'], right_on=[
+                                 'SV_CHROM', 'SV_START', 'SV_END', 'SV_SVTYPE'])
+        overlap = []
+        overlap = ['{}:{}-{}'.format(row['CNV_CHROM'], int(row['CNV_START']), int(row['CNV_END']))
+                   if row['CNV_START'] == row['CNV_START'] else 'nan' for index, row in merged.iterrows()]
+        merged['CNV_overlap'] = overlap
+    merged = merged.drop(columns=['CNV_CHROM', 'CNV_START', 'CNV_END',
+                                  'CNV_SVTYPE', 'SV_CHROM', 'SV_START', 'SV_END', 'SV_SVTYPE'])
+    return merged
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='Adds column to SV and CNV reports indicating if an SV is observed in the CNV report and vice versa')
+    parser.add_argument('-sv', help='SV report (tsv file)', required=True)
+    parser.add_argument('-cnv', help='CNV report (tsv file)', required=True)
+    args = parser.parse_args()
+
+sv_file = args.sv.strip('tsv')
+cnv_file = args.cnv.strip('tsv')
+sv = pd.read_csv(args.sv, sep='\t')
+cnv = pd.read_csv(args.cnv, sep='\t')
+
+# determine overlaps between CNVs and SVs
+overlaps = intersect_variants(cnv, sv)
+
+# export reports with overlap annotation
+overlaps[0].to_csv('{}withSVoverlaps.tsv'.format(cnv_file), sep='\t', index=False, na_rep='nan')
+overlaps[1].to_csv('{}withCNVoverlaps.tsv'.format(sv_file), sep='\t', index=False, na_rep='nan')

--- a/crg.call-svs.sh
+++ b/crg.call-svs.sh
@@ -68,16 +68,3 @@ done
 bcbio_string=$( IFS=$':'; echo "${bcbio_jobs[*]}" )
 
 echo "Setup Complete."
-echo "Save the following commands, and once bcbio jobs: "$( IFS=$', '; echo "${bcbio_jobs[*]}" ) " are done, run them from within the bcbio-sv folder"
-echo "MetaSV:"
-echo '	for f in '${family_id}'_*/'${family_id}'/final/'${family_id}'*; do cd $f; pwd; ls; qsub ~/crg/metasv.pbs -v PROJECT=${family_id},SAMPLE="$(echo $f | sed -n -e 's/.*_//p')"; cd ../../../..; done")'
-echo "SnpEff:"
-echo '	for f in '${family_id}'_*/'${family_id}'/final/'${family_id}'_*/*/*metasv*.gz; do qsub ~/crg/crg.snpeff.sh -F $f; ls; done'
-echo "SVScore:"
-echo '	for f in '${family_id}'_*/'${family_id}'/final/'${family_id}'_*/*/*snpeff*.vcf; do qsub ~/crg/crg.svscore.sh -F $f; done'
-echo "Then create a directory to combine SVScore VCFs and link them:"
-echo '	mkdir combine_vcfs'
-echo '	cd combine_vcfs'
-echo '	for f in ../'${family_id}'_*/'${family_id}'/final/'${family_id}'_*/*/*svscore*.vcf;do ln -s $f . ; done'
-echo "Finally, run the intersect sv script:"
-echo '	~/crg/crg.intersect_sv_vcfs.sh -F '${family_id}

--- a/crg.intersect_sv_vcfs.sh
+++ b/crg.intersect_sv_vcfs.sh
@@ -27,7 +27,7 @@ MSSNG_MANTA_COUNTS=${GENE_DATA}/mssng_counts/Canadian_MSSNG_parent_SVs.Manta.cou
 MSSNG_LUMPY_COUNTS=${GENE_DATA}/mssng_counts/Canadian_MSSNG_parent_SVs.LUMPY.counts.txt
 
 if [ ! $2 ]; then
-	IN_FILES=`ls *.vcf | tr '\n' ' '`
+	IN_FILES=`ls $FAMILY_*/$FAMILY/final/$FAMILY*/$FAMILY*/*svscore.vcf | tr '\n' ' '`
 else
 	IN_FILES=${*:2}
 fi

--- a/crg.merge.annotate.sv.sh
+++ b/crg.merge.annotate.sv.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# usage: crg.merge.annotate.sv.sh <family>
+# run from within family/bcbio-sv/ 
+
+FAMILY=$1
+
+#run metasv on each sample
+for f in $FAMILY_*/$FAMILY/final/$FAMILY* 
+do 
+	cd $f
+	SAMPLE="$(echo $f | cut -d'/' -f1)"
+	metasv_jobs+=($(qsub ~/crg/metasv.pbs -v SAMPLE=$SAMPLE,FAMILY=$FAMILY))
+	cd ../../../..
+done
+metasv_string=$( IFS=$':'; echo "${metasv_jobs[*]}" )
+
+#run snpeff on each sample
+for f in $FAMILY_*/$FAMILY/final/$FAMILY*
+do
+	SAMPLE="$(echo $f | cut -d'/' -f1)"
+	snpeff_jobs+=($(qsub ~/crg/crg.snpeff.sh -F $f/$SAMPLE/*metasv.filtered.vcf.gz -W depend=afterany:"${metasv_string}"))
+done
+snpeff_string=$( IFS=$':'; echo "${snpeff_jobs[*]}" )
+
+#run svscore on each sample
+for f in $FAMILY_*/$FAMILY/final/$FAMILY*
+do
+	SAMPLE="$(echo $f | cut -d'/' -f1)"
+	snpeff_jobs+=($(qsub ~/crg/crg.svscore.sh -F $f/$SAMPLE/*snpeff.vcf -W depend=afterany:"${snpeff_string}"))
+done
+
+echo "Merging SVs with metaSV, annotating with snpeff, and scoring with svscore..."
+
+

--- a/crg.merge.annotate.sv.sh
+++ b/crg.merge.annotate.sv.sh
@@ -26,9 +26,12 @@ snpeff_string=$( IFS=$':'; echo "${snpeff_jobs[*]}" )
 for f in $FAMILY_*/$FAMILY/final/$FAMILY*
 do
 	SAMPLE="$(echo $f | cut -d'/' -f1)"
-	snpeff_jobs+=($(qsub ~/crg/crg.svscore.sh -F $f/$SAMPLE/*snpeff.vcf -W depend=afterany:"${snpeff_string}"))
+	svscore_jobs+=($(qsub ~/crg/crg.svscore.sh -F $f/$SAMPLE/*snpeff.vcf -W depend=afterany:"${snpeff_string}"))
 done
+svscore_string=$( IFS=$':'; echo "${svscore_jobs[*]}" )
 
 echo "Merging SVs with metaSV, annotating with snpeff, and scoring with svscore..."
 
+#ln -s $FAMILY_*/$FAMILY/final/$FAMILY*/$FAMILY*/*svscore.vcf .
+qsub ~/crg/crg.intersect_sv_vcfs.sh -F $FAMILY  -W depend=afterany:"${svscore_string}"
 

--- a/metasv.pbs
+++ b/metasv.pbs
@@ -3,8 +3,7 @@
 #PBS -l walltime=0:20:00,nodes=1:ppn=4
 #PBS -joe .
 #PBS -d .
-#PBS -l vmem=4g,mem=4g
+#PBS -l vmem=8g,mem=8g
 
-SAMPLE=$1
 
-python ~/crg/metasv.py -bam ${SAMPLE}.bam -manta $SAMPLE"-manta.vcf.gz" -lumpy $SAMPLE"-lumpy.vcf.gz" -wham $SAMPLE"-wham.vcf.gz" -sample $SAMPLE
+python ~/crg/metasv.py -bam ${SAMPLE}-ready.bam -manta $FAMILY"-manta.vcf.gz" -lumpy $FAMILY"-lumpy.vcf.gz" -wham $FAMILY"-wham.vcf.gz" -sample $SAMPLE


### PR DESCRIPTION
This is a script to compare the SV and CNV reports. It will add a new column (CNV_overlap and SV_overlap, respectively) to each report. For SVs, the column will contain the coordinate of an CNV with at least 50% reciprocal overlap if it exists, or nan if not. For CNVs, the column will contain the coordinate of an SVV with at least 50% reciprocal overlap if it exists, or nan if not. Only SVs of the same type are compared (ie DEL and DEL, DUP and against DUP).

