### PR TITLE
annotates overlaps between SVs and CNVs on CNV and SV reports 

### DIFF
--- a/SVRecords/SVGrouper.py
+++ b/SVRecords/SVGrouper.py
@@ -146,7 +146,7 @@ class SVGrouper:
         row["%s_GENOTYPE" % samp_name].append(samp_gt)
     
     def write(self, outfile_name):
-        self.df.to_csv(outfile_name, sep='\t', encoding='utf-8')
+        self.df.to_csv(outfile_name, sep='\t', encoding='utf-8', na_rep='.')
 
     def make_ref_bedtool(self):
         return BedTool(list(self.df.index.values))

--- a/cap_report.py
+++ b/cap_report.py
@@ -13,5 +13,6 @@ except Exception as e:
 
 for col in df.columns:
 	df[col] = df[col].apply(lambda x: str(x)[:EXCEL_MAX-1])
+	df[col] = ['.' if val == 'nan' else val for val in df[col].tolist()]
 
-df.to_csv(REPORT, index=False, sep='\t')
+df.to_csv(REPORT, index=False, sep='\t', na_rep='.')

--- a/compare_sv_cnv.py
+++ b/compare_sv_cnv.py
@@ -69,6 +69,15 @@ def update_report(report_df, intersection, variant_type):
     return merged
 
 
+def reorder_columns(report_df):
+    # Takes final annotated report and rearranges columns so overlap columns
+    # is to the right of the 'SVTYPE' columns
+    cols = report_df.columns.tolist()
+    cols = cols[0:4] + [cols[-1]] + cols[5:-1]
+    report_df = report_df[cols]
+    return(report_df)
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description='Adds column to SV and CNV reports indicating if an SV is observed in the CNV report and vice versa')
@@ -84,6 +93,12 @@ if __name__ == "__main__":
     # determine overlaps between CNVs and SVs
     overlaps = intersect_variants(cnv, sv)
 
+    # reorder columns
+    cnv_w_overlap = reorder_columns(overlaps[0])
+    sv_w_overlap = reorder_columns(overlaps[1])
+
     # export reports with overlap annotation
-    overlaps[0].to_csv('{}withSVoverlaps.tsv'.format(cnv_file), sep='\t', index=False, na_rep='nan')
-    overlaps[1].to_csv('{}withCNVoverlaps.tsv'.format(sv_file), sep='\t', index=False, na_rep='nan')
+    cnv_w_overlap.to_csv('{}withSVoverlaps.tsv'.format(
+        cnv_file), sep='\t', index=False, na_rep='nan')
+    sv_w_overlap.to_csv('{}withCNVoverlaps.tsv'.format(
+        sv_file), sep='\t', index=False, na_rep='nan')

--- a/compare_sv_cnv.py
+++ b/compare_sv_cnv.py
@@ -55,14 +55,14 @@ def update_report(report_df, intersection, variant_type):
                                  'CNV_CHROM', 'CNV_START', 'CNV_END', 'CNV_SVTYPE'], validate='1:m')
         overlap = []
         overlap = ['{}:{}-{}'.format(row['SV_CHROM'], int(row['SV_START']), int(row['SV_END']))
-                   if row['SV_START'] == row['SV_START'] else 'nan' for index, row in merged.iterrows()]
+                   if row['SV_START'] == row['SV_START'] else '.' for index, row in merged.iterrows()]
         merged['SV_overlap'] = overlap
     else:
         merged = report_df.merge(intersection, how='left', left_on=['CHROM', 'POS', 'END', 'SVTYPE'], right_on=[
                                  'SV_CHROM', 'SV_START', 'SV_END', 'SV_SVTYPE'], validate='1:m')
         overlap = []
         overlap = ['{}:{}-{}'.format(row['CNV_CHROM'], int(row['CNV_START']), int(row['CNV_END']))
-                   if row['CNV_START'] == row['CNV_START'] else 'nan' for index, row in merged.iterrows()]
+                   if row['CNV_START'] == row['CNV_START'] else '.' for index, row in merged.iterrows()]
         merged['CNV_overlap'] = overlap
     merged = merged.drop(columns=['CNV_CHROM', 'CNV_START', 'CNV_END',
                                   'CNV_SVTYPE', 'SV_CHROM', 'SV_START', 'SV_END', 'SV_SVTYPE'])
@@ -73,7 +73,7 @@ def reorder_columns(report_df):
     # Takes final annotated report and rearranges columns so overlap columns
     # is to the right of the 'SVTYPE' columns
     cols = report_df.columns.tolist()
-    cols = cols[0:4] + [cols[-1]] + cols[5:-1]
+    cols = cols[0:4] + [cols[-1]] + cols[4:-1]
     report_df = report_df[cols]
     return(report_df)
 

--- a/compare_sv_cnv.py
+++ b/compare_sv_cnv.py
@@ -88,6 +88,7 @@ def add_tag(variant_details, intersection, variant_type):
     variant_overlap = 'CNV' if variant_type == 'sv' else 'SV'
 
     if (variant_details == variant_details) and (intersection == intersection):
+        intersection = '50' if 'rec50' in intersection else 'any'
         variant_details = variant_details + ":{}_{}".format(variant_overlap, intersection)
     else:
         pass

--- a/compare_sv_cnv.py
+++ b/compare_sv_cnv.py
@@ -1,0 +1,89 @@
+import argparse
+import numpy as np
+import pandas as pd
+from pybedtools import BedTool
+
+
+def intersect_variants(cnv, sv):
+    # get coordinates of DEL and DUP from SV and CNV reports
+    sv_coord = sv[['CHROM', 'POS', 'END', 'SVTYPE']]
+    sv_coord = sv_coord[(sv_coord['SVTYPE'] != 'INV')
+                        & (sv_coord['SVTYPE'] != 'INS')]
+    cnv_coord = cnv[['CHROM', 'START', 'END', 'SVTYPE']]
+
+    # convert report dataframes to bedtools
+    cnv_bed = BedTool.from_dataframe(cnv_coord)
+    sv_bed = BedTool.from_dataframe(sv_coord)
+
+    # intersect CNV and SV bed files with reciprocal overlap of 50%
+    intersection = cnv_bed.intersect(sv_bed, wa=True, wb=True, F=0.5,
+                                     f=0.5).saveas('intersection.bed')
+    intersection = pd.read_csv('intersection.bed', sep='\t', names=['CNV_CHROM', 'CNV_START', 'CNV_END', 'CNV_SVTYPE', 'SV_CHROM',
+                                                                    'SV_START', 'SV_END', 'SV_SVTYPE'])
+    # remove overlapping SVs that are different SVTYPES
+    intersection = intersection[intersection['CNV_SVTYPE'] == intersection['SV_SVTYPE']]
+
+    # make reports updated with overlap column
+    merged_cnv = update_report(cnv, intersection, 'cnv')
+    merged_sv = update_report(sv, intersection, 'sv')
+
+    return collapse_overlaps(merged_cnv, 'cnv'), collapse_overlaps(merged_sv, 'sv')
+
+
+def collapse_overlaps(report_df, variant_type):
+    # if a variant (e.g. CNV) overlaps with muliple variants,
+    # (e.g. multiple SVs), collapse and create one record
+    # with a comma-separated list of overlapping variants
+    overlap_col = 'SV_overlap' if variant_type == 'cnv' else 'CNV_overlap'
+    start_col = 'START' if variant_type == 'cnv' else 'POS'
+    # concatenate overlapping SVs
+    merged_overlaps = report_df.groupby(['CHROM', start_col, 'END', 'SVTYPE'])[
+        overlap_col].apply(','.join).reset_index()
+    report_df = report_df.drop(overlap_col, axis=1)
+    # merge report variants with merged overlaps df to replace overlap
+    # annotations with list of overlaps, then drop duplicates
+    report_df = report_df.merge(merged_overlaps, how='left', on=[
+                                'CHROM', start_col, 'END', 'SVTYPE']).drop_duplicates()
+
+    return report_df
+
+
+def update_report(report_df, intersection, variant_type):
+    # join overlap dataframe with report dataframe to annotate overlaps
+    if variant_type == 'cnv':
+        merged = report_df.merge(intersection, how='left', left_on=['CHROM', 'START', 'END', 'SVTYPE'], right_on=[
+                                 'CNV_CHROM', 'CNV_START', 'CNV_END', 'CNV_SVTYPE'], validate='1:m')
+        overlap = []
+        overlap = ['{}:{}-{}'.format(row['SV_CHROM'], int(row['SV_START']), int(row['SV_END']))
+                   if row['SV_START'] == row['SV_START'] else 'nan' for index, row in merged.iterrows()]
+        merged['SV_overlap'] = overlap
+    else:
+        merged = report_df.merge(intersection, how='left', left_on=['CHROM', 'POS', 'END', 'SVTYPE'], right_on=[
+                                 'SV_CHROM', 'SV_START', 'SV_END', 'SV_SVTYPE'], validate='1:m')
+        overlap = []
+        overlap = ['{}:{}-{}'.format(row['CNV_CHROM'], int(row['CNV_START']), int(row['CNV_END']))
+                   if row['CNV_START'] == row['CNV_START'] else 'nan' for index, row in merged.iterrows()]
+        merged['CNV_overlap'] = overlap
+    merged = merged.drop(columns=['CNV_CHROM', 'CNV_START', 'CNV_END',
+                                  'CNV_SVTYPE', 'SV_CHROM', 'SV_START', 'SV_END', 'SV_SVTYPE'])
+    return merged
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='Adds column to SV and CNV reports indicating if an SV is observed in the CNV report and vice versa')
+    parser.add_argument('-sv', help='SV report (tsv file)', required=True)
+    parser.add_argument('-cnv', help='CNV report (tsv file)', required=True)
+    args = parser.parse_args()
+
+    sv_file = args.sv.strip('tsv')
+    cnv_file = args.cnv.strip('tsv')
+    sv = pd.read_csv(args.sv, sep='\t')
+    cnv = pd.read_csv(args.cnv, sep='\t')
+
+    # determine overlaps between CNVs and SVs
+    overlaps = intersect_variants(cnv, sv)
+
+    # export reports with overlap annotation
+    overlaps[0].to_csv('{}withSVoverlaps.tsv'.format(cnv_file), sep='\t', index=False, na_rep='nan')
+    overlaps[1].to_csv('{}withCNVoverlaps.tsv'.format(sv_file), sep='\t', index=False, na_rep='nan')

--- a/crg.intersect_sv_vcfs.py
+++ b/crg.intersect_sv_vcfs.py
@@ -54,7 +54,7 @@ def main(protein_coding_genes, exon_bed, hgmd_db, hpo, exac, omim, biomart, gnom
     [ "DGV_GAIN_IDs", "DGV_GAIN_n_samples_with_SV", "DGV_GAIN_n_samples_tested", "DGV_GAIN_Frequency", ] + \
     [ "DGV_LOSS_IDs", "DGV_LOSS_n_samples_with_SV", "DGV_LOSS_n_samples_tested", "DGV_LOSS_Frequency", ] + \
     [ "gnomAD_AF", "gnomAD_SV", "gnomAD_AN", "gnomAD_AC", "gnomAD_N_HOMREF", "gnomAD_N_HET", "gnomAD_N_HOMALT", "gnomAD_FREQ_HOMREF", "gnomAD_FREQ_HET", "gnomAD_FREQ_HOMALT", "gnomAD_POPMAX_AF" ] + \
-    [ "DDD_mode", "DDD_pmids", ] + \
+    [ "DDD_disease", "DDD_mode", "DDD_pmids", ] + \
     [ "Genes in HGMD", "HGMD disease", "HGMD descr", "HGMD JOURNAL_DETAILS" ] + \
     [ "ExAC syn_z", "ExAC mis_z", "ExAC lof_z", "ExAC pLI" ] + \
     [ col for col in SVScore_cols if col != 'variants/SVLEN'] + \

--- a/crg.intersect_sv_vcfs.py
+++ b/crg.intersect_sv_vcfs.py
@@ -54,11 +54,12 @@ def main(protein_coding_genes, exon_bed, hgmd_db, hpo, exac, omim, biomart, gnom
     [ "DGV_LOSS_IDs", "DGV_LOSS_n_samples_with_SV", "DGV_LOSS_n_samples_tested", "DGV_LOSS_Frequency", ] + \
     [ "gnomAD_AF", "gnomAD_SV", "gnomAD_AN", "gnomAD_AC", "gnomAD_N_HOMREF", "gnomAD_N_HET", "gnomAD_N_HOMALT", "gnomAD_FREQ_HOMREF", "gnomAD_FREQ_HET", "gnomAD_FREQ_HOMALT", "gnomAD_POPMAX_AF" ] + \
     [ "DDD_mode", "DDD_pmids", ] + \
-    [ "Genes in HGMD", "HGMD disease", "HGMD tag", "HGMD descr", "HGMD JOURNAL_DETAILS" ] + \
+    [ "Genes in HGMD", "HGMD disease", "HGMD descr", "HGMD JOURNAL_DETAILS" ] + \
     [ "ExAC syn_z", "ExAC mis_z", "ExAC lof_z", "ExAC pLI" ] + \
     [ col for col in SVScore_cols if col != 'variants/SVLEN'] + \
     [ "DECIPHER_LINK" ] ]
     sv_records.df.columns = sv_records.df.columns.str.replace('variants/','')
+    sv_records.df = sv_records.df.drop_duplicates()
 
     # [ "DDD_SV", "DDD_DUP_n_samples_with_SV", "DDD_DUP_Frequency", "DDD_DEL_n_samples_with_SV", "DDD_DEL_Frequency" ]
 

--- a/crg.intersect_sv_vcfs.py
+++ b/crg.intersect_sv_vcfs.py
@@ -35,6 +35,7 @@ def main(protein_coding_genes, exon_bed, hgmd_db, hpo, exac, omim, biomart, gnom
     sv_records.df = ann_records.annotate_gnomad(gnomad, sv_records)
     sv_records.df = ann_records.annotate_hgmd(hgmd_db, sv_records.df)
     ann_records.add_decipher_link(sv_records.df)
+    sv_records.df = ann_records.calc_exon_boundaries(sv_records.df.reset_index(), exon_bed)
 
     if not set(HPO_cols).issubset(set(sv_records.df.columns)):
         for col in HPO_cols:
@@ -57,11 +58,23 @@ def main(protein_coding_genes, exon_bed, hgmd_db, hpo, exac, omim, biomart, gnom
     [ "Genes in HGMD", "HGMD disease", "HGMD descr", "HGMD JOURNAL_DETAILS" ] + \
     [ "ExAC syn_z", "ExAC mis_z", "ExAC lof_z", "ExAC pLI" ] + \
     [ col for col in SVScore_cols if col != 'variants/SVLEN'] + \
+    [ "nearestLeftExonBoundary", "nearestLeftExonDistance", "nearestRightExonBoundary", "nearestRightExonDistance", ] + \
     [ "DECIPHER_LINK" ] ]
     sv_records.df.columns = sv_records.df.columns.str.replace('variants/','')
     sv_records.df = sv_records.df.drop_duplicates()
 
     # [ "DDD_SV", "DDD_DUP_n_samples_with_SV", "DDD_DUP_Frequency", "DDD_DEL_n_samples_with_SV", "DDD_DEL_Frequency" ]
+
+    # set missing values in numeric columns to 0, and '.' in non-numeric columns
+    numeric =  [ "N_GENES_IN_HPO", "N_UNIQUE_HPO_TERMS", "N_GENES_IN_OMIM","gnomAD_AF", "gnomAD_AN", "gnomAD_AC", "gnomAD_N_HOMREF", "gnomAD_N_HET", "gnomAD_N_HOMALT", "gnomAD_FREQ_HOMREF", "gnomAD_FREQ_HET", "gnomAD_FREQ_HOMALT", "gnomAD_POPMAX_AF" ]
+    non_numeric = [col for col in sv_records.df.columns if col not in numeric]
+    for col in numeric:
+        sv_records.df[col] = [val if val == val else '0' for val in sv_records.df[col].tolist()]
+    for col in non_numeric:
+        sv_records.df[col] = ['.' if val == 'na' else val for val in sv_records.df[col].tolist()]
+        sv_records.df[col] = ['.' if val == '' else val for val in sv_records.df[col].tolist()]
+        sv_records.df[col] = ['.' if val == 'nan' else val for val in sv_records.df[col].tolist()]
+
 
     print('Writing results to file ...')
     sv_records.write(outfile_name)

--- a/crg.intersect_sv_vcfs.sh
+++ b/crg.intersect_sv_vcfs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#PBS -l walltime=0:30:00,nodes=1:ppn=1
+#PBS -l walltime=2:00:00,nodes=1:ppn=1
 #PBS -joe .
 #PBS -d .
 #PBS -l vmem=10g,mem=10g
@@ -17,7 +17,7 @@ OUT=${FAMILY_ID}.wgs.sv.${TODAY}.tsv
 GENE_DATA=${HOME}/gene_data
 HGMD=${GENE_DATA}/HGMD_2018/hgmd_pro.db
 PROTEIN_CODING_GENES=${GENE_DATA}/grch37.p13.ensembl.sorted.protein.coding.genes.bed
-EXON_BED=${GENE_DATA}/protein_coding_genes.exons.fixed.sorted.bed
+EXON_BED=${GENE_DATA}/exons/hg19_UCSC_exons_canonical.bed
 HPO=${GENE_DATA}/HPO/${FAMILY_ID}_HPO.txt
 EXAC=${GENE_DATA}/ExAC/fordist_cleaned_nonpsych_z_pli_rec_null_data.txt
 OMIM=${GENE_DATA}/OMIM_2020-04-09/genemap2.txt


### PR DESCRIPTION
This is a script to compare the SV and CNV reports. It will add a new column (CNV_overlap and SV_overlap, respectively) to each report. For SVs, the column will contain the coordinate of an CNV with at least 50% reciprocal overlap if it exists, or nan if not. For CNVs, the column will contain the coordinate of an SVV with at least 50% reciprocal overlap if it exists, or nan if not. Only SVs of the same type are compared (ie DEL and DEL, DUP and against DUP). If there are multiple overlaps, these are reported as a comma separated list. 