### PR TITLE
script for reannotating and reporting variants from WGS

### DIFF
--- a/crg.vcf2cre.sh
+++ b/crg.vcf2cre.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#PBS -l walltime=23:00:00,nodes=1:ppn=1
+#PBS -l walltime=23:00:00,nodes=1:ppn=5
 #PBS -joe .
 #PBS -d .
 #PBS -l vmem=50g,mem=50g

--- a/generate_reports.sh
+++ b/generate_reports.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# generate both the regular and synonymous reports for a family
+# pass in the family id as the first positional parameter, use -email to recieve an email when both jobs are done
+# usage: generate_reports.sh <family id> <report_type> [optional -email] 
+
+family=$1
+report_type=$2
+
+
+if [ "$3" == "-email" ]; then
+  email_flag="-m e"
+else
+	email_flag=""
+fi
+
+cd $family
+family_vcf="${family}-ensemble-annotated-decomposed.vcf.gz"
+
+if [ -f $family_vcf ]; then
+	if [ "$report_type" = wes ]; then
+		vcf2cre_job="$(qsub ~/cre/cre.vcf2cre.sh -v original_vcf="${family}-gatk-haplotype-annotated-decomposed.vcf.gz",project=${family})"
+	elif [ "$report_type" = wgs ]; then
+		vcf2cre_job="$(qsub ~/crg/crg.vcf2cre.sh -v original_vcf="${family}-ensemble-annotated-decomposed.vcf.gz",project=${family})"
+	fi
+else
+	echo "${family_vcf} Not Present, Aborting."
+	cd ..
+	exit
+fi
+
+if [ "$report_type" = wes ]; then
+	standard_job="$(qsub ~/cre/cre.sh -W depend=afterany:"${vcf2cre_job}" -v family=${family})"
+	echo "Standard WES Report Job ID: ${standard_job}"
+elif [ "$report_type" = wgs ]; then
+	standard_job="$(qsub ~/cre/cre.sh -W depend=afterany:"${vcf2cre_job}" -v family=${family},type=wgs)"
+        echo "WGS Report Job ID: ${standard_job}"
+fi
+
+
+echo "The Rerun subfolder will be renamed by the current date after the reports are created"
+cleanup_job="$(qsub ~/cre/rename_rerun.sh -W depend=afterok:"${standard_job}" -v family=${family})"
+
+cd ..

--- a/panel_report.sh
+++ b/panel_report.sh
@@ -13,14 +13,14 @@ fi;
 panel_vcf="${dir}/${family}/${family}-ensemble-annotated-decomposed.vcf.gz";
 echo "$panel_vcf, $ensemble, $bed";
 
-if [ ! -f "$panel_vcf" ]; then
+if [ ! -f "${panel_vcf}" ]; then
 	echo "generating ${panel_vcf}";
 	bedtools intersect -header -a $ensemble -b $bed > ${panel_vcf}
 fi;
 
 cd ${dir}
 echo "report generation for $dir"
-sh ~/crg/generate_reports.sh ${family} "wgs"
+sh ~/cre/generate_reports.sh ${family} "wgs"
 cd ..
 
 }
@@ -38,7 +38,10 @@ fi;
 panel_report
 
 #panel flank
-~/crg/crg.flank.sh $bed > genes/${family}.flank.100k.bed
+if [ ! -f "genes/${family}.flank.100k.bed" ]; then
+	~/crg/crg.flank.sh $bed > genes/${family}.flank.100k.bed
+fi;
+
 dir="panel-flank100k";
 bed="genes/${family}.flank.100k.bed";
 panel_report

--- a/panel_report.sh
+++ b/panel_report.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+#usage: sh panel_report.sh <family> <path/to/ensemble.vcf.gz>
+#run this from base <family> folder
+
+function panel_report
+{
+
+if [ ! -d "${dir}/${family}" ]; then
+	mkdir ${dir}/${family}
+fi;
+
+panel_vcf="${dir}/${family}/${family}-ensemble-annotated-decomposed.vcf.gz";
+echo "$panel_vcf, $ensemble, $bed";
+
+if [ ! -f "$panel_vcf" ]; then
+	echo "generating ${panel_vcf}";
+	bedtools intersect -header -a $ensemble -b $bed > ${panel_vcf}
+fi;
+
+cd ${dir}
+echo "report generation for $dir"
+sh ~/crg/generate_reports.sh ${family} "wgs"
+cd ..
+
+}
+
+family=$1;
+ensemble=$2; #ensemble annotated vcf.gz from small-variant
+
+#panel
+dir="panel";
+bed="genes/${family}.bed"
+if [ ! -d genes ] || [ ! -f $bed ]; then
+	echo "folder: genes or file: genes/${family}.bed not found. Exiting!";
+	exit
+fi;
+panel_report
+
+#panel flank
+~/crg/crg.flank.sh $bed > genes/${familyid}.flank.100k.bed
+dir="panel-flank100k";
+bed="genes/${familyid}.flank.100k.bed";
+panel_report

--- a/panel_report.sh
+++ b/panel_report.sh
@@ -38,7 +38,7 @@ fi;
 panel_report
 
 #panel flank
-~/crg/crg.flank.sh $bed > genes/${familyid}.flank.100k.bed
+~/crg/crg.flank.sh $bed > genes/${family}.flank.100k.bed
 dir="panel-flank100k";
-bed="genes/${familyid}.flank.100k.bed";
+bed="genes/${family}.flank.100k.bed";
 panel_report


### PR DESCRIPTION
Use generate_reports.sh to re-annotate and generate reports for coding, panel, and panel-flank variants. 
Usage: generate_reports.sh <family_id> <report_type>
Where report_type is 'wes' if generating coding variants, or 'wgs' if generating panel/panel-flank variants. 